### PR TITLE
Pass message property in Algolia error message

### DIFF
--- a/src/checks/noDependencyProblems/noDependenciesWithoutTypes.ts
+++ b/src/checks/noDependencyProblems/noDependenciesWithoutTypes.ts
@@ -74,7 +74,7 @@ export default async function noDependenciesWithoutTypes() {
         // Show dependency name if Algolia's `index.getObject()` throws with an
         // error message (such as the error message "ObjectID does not exist"
         // when a package cannot be found in the index)
-        throw new Error(`Algolia error for \`${dependency}\`: ${err}`);
+        throw new Error(`Algolia error for \`${dependency}\`: ${err.message}`);
       }
 
       const definitelyTypedPackageName = results.types?.definitelyTyped;


### PR DESCRIPTION
Current behaviour:
```
 ✖ No dependencies without types
    › Algolia error for `@apollo/experimental-nextjs-app-support`: [object Object]
```
Expected result:
```
 ✖ No dependencies without types
    › Algolia error for `@apollo/experimental-nextjs-app-support`: ObjectID does not exist
```
